### PR TITLE
move glog from surgebase/glog to surge/glog

### DIFF
--- a/ip_test.go
+++ b/ip_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/surgebase/glog"
+	"github.com/surge/glog"
 )
 
 type IPAdder interface {

--- a/ping.go
+++ b/ping.go
@@ -39,7 +39,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/surgebase/glog"
+	"github.com/surge/glog"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"

--- a/ping_test.go
+++ b/ping_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/surgebase/glog"
+	"github.com/surge/glog"
 )
 
 func TestPingerAddIPs(t *testing.T) {


### PR DESCRIPTION
surgebase/glog was moved to surge/glog.
It causes trouble with surgemq/examples/pingmq which uses surge/glog,
because same flags are registered twice by both surgebase/glog and surge/glog.
